### PR TITLE
Static typing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,3 +39,6 @@ jobs:
       - name: Test with pytest
         run: |
           pytest
+      - name: Test with mypy
+        run: |
+          mypy

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ wheels/
 
 # C extensions
 *.so
+
+# mypy
+.mypy_cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,22 @@ author = "Maurice Berk"
 author_email = "maurice@mauriceberk.com"
 url = "https://github.com/mberk/shin"
 readme = "README.md"
+
+[tool.mypy]
+python_version = "3.8"
+packages = ["shin", "tests"]
+enable_error_code = [
+    "explicit-override",
+    "ignore-without-code",
+    "possibly-undefined",
+    "redundant-expr",
+    "redundant-self",
+    "truthy-bool",
+    "truthy-iterable",
+    "unimported-reveal",
+    "unused-awaitable",
+]
+disallow_any_unimported = true
+show_error_codes = true
+strict = true
+warn_unreachable = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ url = "https://github.com/mberk/shin"
 readme = "README.md"
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 packages = ["shin", "tests"]
 enable_error_code = [
     "explicit-override",

--- a/python/shin/__init__.py
+++ b/python/shin/__init__.py
@@ -58,7 +58,9 @@ class FullOutput(Generic[OutputT]):
     def __getitem__(self, key: Literal["z"]) -> float:
         ...
 
-    def __getitem__(self, key: Literal["implied_probabilities", "iterations", "delta", "z"]) -> Any:
+    def __getitem__(
+        self, key: Literal["implied_probabilities", "iterations", "delta", "z"]
+    ) -> Any:
         try:
             return getattr(self, key)
         except AttributeError:

--- a/python/shin/__init__.py
+++ b/python/shin/__init__.py
@@ -38,24 +38,18 @@ def calculate_implied_probabilities(
     full_output: bool = False,
     force_python_optimiser: bool = False,
 ) -> Union[dict[str, Any], list[float], dict[Any, float]]:
-    if isinstance(odds, Mapping):
-        keys = odds.keys()
-        odds = odds.values()
-        _class = odds.__class__
-    else:
-        keys = None
-        _class = None
+    odds_seq = odds.values() if isinstance(odds, Mapping) else odds
 
-    if len(odds) < 2:
+    if len(odds_seq) < 2:
         raise ValueError("len(odds) must be >= 2")
 
-    if any(o < 1 for o in odds):
+    if any(o < 1 for o in odds_seq):
         raise ValueError("All odds must be >= 1")
 
     optimise = _optimise if force_python_optimiser else _optimise_rust
 
-    n = len(odds)
-    inverse_odds = [1.0 / o for o in odds]
+    n = len(odds_seq)
+    inverse_odds = [1.0 / o for o in odds_seq]
     sum_inverse_odds = sum(inverse_odds)
 
     if n == 2:
@@ -78,8 +72,8 @@ def calculate_implied_probabilities(
         (sqrt(z**2 + 4 * (1 - z) * io**2 / sum_inverse_odds) - z) / (2 * (1 - z))
         for io in inverse_odds
     ]
-    if keys is not None:
-        p = {k: v for k, v in zip(keys, p)}
+    if isinstance(odds, Mapping):
+        p = {k: v for k, v in zip(odds, p)}
 
     if full_output:
         return {

--- a/python/shin/__init__.py
+++ b/python/shin/__init__.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 from collections.abc import Collection
 from collections.abc import Mapping
 from math import sqrt
-from typing import Any, Union
-
+from typing import Any
 
 from .shin import optimise as _optimise_rust
 
@@ -32,12 +33,12 @@ def _optimise(
 
 
 def calculate_implied_probabilities(
-    odds: Union[Collection[float], Mapping[Any, float]],
+    odds: Collection[float] | Mapping[Any, float],
     max_iterations: int = 1000,
     convergence_threshold: float = 1e-12,
     full_output: bool = False,
     force_python_optimiser: bool = False,
-) -> Union[dict[str, Any], list[float], dict[Any, float]]:
+) -> dict[str, Any] | list[float] | dict[Any, float]:
     odds_seq = odds.values() if isinstance(odds, Mapping) else odds
 
     if len(odds_seq) < 2:
@@ -68,7 +69,7 @@ def calculate_implied_probabilities(
             convergence_threshold=convergence_threshold,
         )
 
-    p: Union[list[float], dict[Any, float]] = [
+    p: list[float] | dict[Any, float] = [
         (sqrt(z**2 + 4 * (1 - z) * io**2 / sum_inverse_odds) - z) / (2 * (1 - z))
         for io in inverse_odds
     ]

--- a/python/shin/__init__.py
+++ b/python/shin/__init__.py
@@ -36,7 +36,7 @@ def _optimise(
 
 
 @dataclass
-class FullOutput(Generic[OutputT]):
+class ShinOptimisationDetails(Generic[OutputT]):
     implied_probabilities: OutputT
     iterations: float
     delta: float
@@ -102,7 +102,7 @@ def calculate_implied_probabilities(
     convergence_threshold: float = ...,
     full_output: Literal[True],
     force_python_optimiser: bool = ...,
-) -> FullOutput[list[float]]:
+) -> ShinOptimisationDetails[list[float]]:
     ...
 
 
@@ -115,7 +115,7 @@ def calculate_implied_probabilities(
     convergence_threshold: float = ...,
     full_output: Literal[True],
     force_python_optimiser: bool = ...,
-) -> FullOutput[dict[T, float]]:
+) -> ShinOptimisationDetails[dict[T, float]]:
     ...
 
 
@@ -127,7 +127,10 @@ def calculate_implied_probabilities(
     full_output: bool = False,
     force_python_optimiser: bool = False,
 ) -> (
-    FullOutput[list[float]] | FullOutput[dict[T, float]] | list[float] | dict[T, float]
+    ShinOptimisationDetails[list[float]]
+    | ShinOptimisationDetails[dict[T, float]]
+    | list[float]
+    | dict[T, float]
 ):
     odds_seq = odds.values() if isinstance(odds, Mapping) else odds
 
@@ -166,7 +169,7 @@ def calculate_implied_probabilities(
     if isinstance(odds, Mapping):
         d = {k: v for k, v in zip(odds, p_gen)}
         if full_output:
-            return FullOutput(
+            return ShinOptimisationDetails(
                 implied_probabilities=d,
                 iterations=iterations,
                 delta=delta,
@@ -176,7 +179,7 @@ def calculate_implied_probabilities(
 
     l = list(p_gen)
     if full_output:
-        return FullOutput(
+        return ShinOptimisationDetails(
             implied_probabilities=l,
             iterations=iterations,
             delta=delta,

--- a/python/shin/__init__.py
+++ b/python/shin/__init__.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from math import sqrt
-from typing import Any, Literal, overload
+from typing import Any, Literal, TypeVar, overload
 
 from .shin import optimise as _optimise_rust
+
+T = TypeVar("T")
 
 
 def _optimise(
@@ -47,13 +49,13 @@ def calculate_implied_probabilities(
 # mapping, full output False
 @overload
 def calculate_implied_probabilities(
-    odds: Mapping[Any, float],
+    odds: Mapping[T, float],
     *,
     max_iterations: int = ...,
     convergence_threshold: float = ...,
     full_output: Literal[False] = False,
     force_python_optimiser: bool = ...,
-) -> dict[Any, float]:
+) -> dict[T, float]:
     ...
 
 
@@ -71,13 +73,13 @@ def calculate_implied_probabilities(
 
 
 def calculate_implied_probabilities(
-    odds: Sequence[float] | Mapping[Any, float],
+    odds: Sequence[float] | Mapping[T, float],
     *,
     max_iterations: int = 1000,
     convergence_threshold: float = 1e-12,
     full_output: bool = False,
     force_python_optimiser: bool = False,
-) -> dict[str, Any] | list[float] | dict[Any, float]:
+) -> dict[str, Any] | list[float] | dict[T, float]:
     odds_seq = odds.values() if isinstance(odds, Mapping) else odds
 
     if len(odds_seq) < 2:

--- a/python/shin/__init__.py
+++ b/python/shin/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from math import sqrt
-from typing import Any
+from typing import Any, Literal, overload
 
 from .shin import optimise as _optimise_rust
 
@@ -31,8 +31,48 @@ def _optimise(
     return z, delta, iterations
 
 
+# sequence input, full output False
+@overload
+def calculate_implied_probabilities(
+    odds: Sequence[float],
+    *,
+    max_iterations: int = ...,
+    convergence_threshold: float = ...,
+    full_output: Literal[False] = False,
+    force_python_optimiser: bool = ...,
+) -> list[float]:
+    ...
+
+
+# mapping, full output False
+@overload
+def calculate_implied_probabilities(
+    odds: Mapping[Any, float],
+    *,
+    max_iterations: int = ...,
+    convergence_threshold: float = ...,
+    full_output: Literal[False] = False,
+    force_python_optimiser: bool = ...,
+) -> dict[Any, float]:
+    ...
+
+
+# full output True
+@overload
 def calculate_implied_probabilities(
     odds: Sequence[float] | Mapping[Any, float],
+    *,
+    max_iterations: int = ...,
+    convergence_threshold: float = ...,
+    full_output: Literal[True],
+    force_python_optimiser: bool = ...,
+) -> dict[str, Any]:
+    ...
+
+
+def calculate_implied_probabilities(
+    odds: Sequence[float] | Mapping[Any, float],
+    *,
     max_iterations: int = 1000,
     convergence_threshold: float = 1e-12,
     full_output: bool = False,

--- a/python/shin/__init__.py
+++ b/python/shin/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from math import sqrt
-from typing import Generic, Literal, TypeVar, overload
+from typing import Any, Generic, Literal, TypeVar, overload
 
 from .shin import optimise as _optimise_rust
 

--- a/python/shin/__init__.py
+++ b/python/shin/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Collection
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from math import sqrt
 from typing import Any
 
@@ -33,7 +32,7 @@ def _optimise(
 
 
 def calculate_implied_probabilities(
-    odds: Collection[float] | Mapping[Any, float],
+    odds: Sequence[float] | Mapping[Any, float],
     max_iterations: int = 1000,
     convergence_threshold: float = 1e-12,
     full_output: bool = False,

--- a/python/shin/__init__.py
+++ b/python/shin/__init__.py
@@ -15,7 +15,7 @@ def _optimise(
     convergence_threshold: float = 1e-12,
 ) -> tuple[float, float, float]:
     delta = float("Inf")
-    z = 0
+    z = 0.0
     iterations = 0
     while delta > convergence_threshold and iterations < max_iterations:
         z0 = z
@@ -63,8 +63,8 @@ def calculate_implied_probabilities(
         z = ((sum_inverse_odds - 1) * (diff_inverse_odds**2 - sum_inverse_odds)) / (
             sum_inverse_odds * (diff_inverse_odds**2 - 1)
         )
-        delta = 0
-        iterations = 0
+        delta = 0.0
+        iterations = 0.0
     else:
         z, delta, iterations = optimise(
             inverse_odds=inverse_odds,

--- a/python/shin/__init__.py
+++ b/python/shin/__init__.py
@@ -42,6 +42,28 @@ class FullOutput(Generic[OutputT]):
     delta: float
     z: float
 
+    @overload
+    def __getitem__(self, key: Literal["implied_probabilities"]) -> OutputT:
+        ...
+
+    @overload
+    def __getitem__(self, key: Literal["iterations"]) -> float:
+        ...
+
+    @overload
+    def __getitem__(self, key: Literal["delta"]) -> float:
+        ...
+
+    @overload
+    def __getitem__(self, key: Literal["z"]) -> float:
+        ...
+
+    def __getitem__(self, key: Literal["implied_probabilities", "iterations", "delta", "z"]) -> Any:
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
 
 # sequence input, full output False
 @overload

--- a/python/shin/__init__.py
+++ b/python/shin/__init__.py
@@ -74,7 +74,7 @@ def calculate_implied_probabilities(
             convergence_threshold=convergence_threshold,
         )
 
-    p = [
+    p: Union[list[float], dict[Any, float]] = [
         (sqrt(z**2 + 4 * (1 - z) * io**2 / sum_inverse_odds) - z) / (2 * (1 - z))
         for io in inverse_odds
     ]

--- a/python/shin/__init__.py
+++ b/python/shin/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from math import sqrt
-from typing import Any, Generic, Literal, TypeAlias, TypeVar, overload
+from typing import Generic, Literal, TypeVar, overload
 
 from .shin import optimise as _optimise_rust
 
@@ -102,7 +102,9 @@ def calculate_implied_probabilities(
     convergence_threshold: float = 1e-12,
     full_output: bool = False,
     force_python_optimiser: bool = False,
-) -> FullOutput[list[float]] | FullOutput[dict[T, float]] | list[float] | dict[T, float]:
+) -> (
+    FullOutput[list[float]] | FullOutput[dict[T, float]] | list[float] | dict[T, float]
+):
     odds_seq = odds.values() if isinstance(odds, Mapping) else odds
 
     if len(odds_seq) < 2:

--- a/python/shin/shin.pyi
+++ b/python/shin/shin.pyi
@@ -2,7 +2,6 @@ def optimise(
     inverse_odds: list[float],
     sum_inverse_odds: float,
     n: int,
-    max_iterations: int = 1000,
-    convergence_threshold: float = 1e-12,
-) -> tuple[float, float, float]:
-    ...
+    max_iterations: int = ...,
+    convergence_threshold: float = ...,
+) -> tuple[float, float, float]: ...

--- a/python/shin/shin.pyi
+++ b/python/shin/shin.pyi
@@ -1,0 +1,8 @@
+def optimise(
+    inverse_odds: list[float],
+    sum_inverse_odds: float,
+    n: int,
+    max_iterations: int = 1000,
+    convergence_threshold: float = 1e-12,
+) -> tuple[float, float, float]:
+    ...

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,4 @@
 black==23.10.1
+mypy==1.8.0
 pytest==7.4.3
+pytest-mypy-plugins==3.0.0

--- a/tests/test_shin.py
+++ b/tests/test_shin.py
@@ -15,19 +15,19 @@ def test_calculate_implied_probabilities():
 
     result = shin.calculate_implied_probabilities([2.6, 2.4, 4.3], full_output=True)
 
-    assert pytest.approx(0.3729941) == result["implied_probabilities"][0]
-    assert pytest.approx(0.4047794) == result["implied_probabilities"][1]
-    assert pytest.approx(0.2222265) == result["implied_probabilities"][2]
-    assert pytest.approx(0.01694251) == result["z"]
+    assert pytest.approx(0.3729941) == result.implied_probabilities[0]
+    assert pytest.approx(0.4047794) == result.implied_probabilities[1]
+    assert pytest.approx(0.2222265) == result.implied_probabilities[2]
+    assert pytest.approx(0.01694251) == result.z
 
     result = shin.calculate_implied_probabilities(
         [2.6, 2.4, 4.3], full_output=True, force_python_optimiser=True
     )
 
-    assert pytest.approx(0.3729941) == result["implied_probabilities"][0]
-    assert pytest.approx(0.4047794) == result["implied_probabilities"][1]
-    assert pytest.approx(0.2222265) == result["implied_probabilities"][2]
-    assert pytest.approx(0.01694251) == result["z"]
+    assert pytest.approx(0.3729941) == result.implied_probabilities[0]
+    assert pytest.approx(0.4047794) == result.implied_probabilities[1]
+    assert pytest.approx(0.2222265) == result.implied_probabilities[2]
+    assert pytest.approx(0.01694251) == result.z
 
     result = shin.calculate_implied_probabilities([2.6, 2.4, 4.3])
     assert pytest.approx(0.3729941) == result[0]
@@ -50,23 +50,23 @@ def test_calculate_implied_probabilities():
         "HOME": pytest.approx(0.3729941),
         "AWAY": pytest.approx(0.4047794),
         "DRAW": pytest.approx(0.2222265),
-    } == result["implied_probabilities"]
-    assert pytest.approx(0.01694251) == result["z"]
+    } == result.implied_probabilities
+    assert pytest.approx(0.01694251) == result.z
 
     odds = [1.5, 2.74]
     inverse_odds = [1 / o for o in odds]
     sum_inverse_odds = sum(inverse_odds)
     result = shin.calculate_implied_probabilities(odds, full_output=True)
 
-    assert result["iterations"] == 0
-    assert result["delta"] == 0
+    assert result.iterations == 0
+    assert result.delta == 0
 
     # With two outcomes, Shin is equivalent to the Additive Method described in Clarke et al. (2017)
     assert (
         pytest.approx(inverse_odds[0] - (sum_inverse_odds - 1) / 2)
-        == result["implied_probabilities"][0]
+        == result.implied_probabilities[0]
     )
     assert (
         pytest.approx(inverse_odds[1] - (sum_inverse_odds - 1) / 2)
-        == result["implied_probabilities"][1]
+        == result.implied_probabilities[1]
     )

--- a/tests/test_shin.py
+++ b/tests/test_shin.py
@@ -3,7 +3,7 @@ import pytest
 import shin
 
 
-def test_calculate_implied_probabilities():
+def test_calculate_implied_probabilities_error_conditions() -> None:
     with pytest.raises(ValueError):
         shin.calculate_implied_probabilities([])
 
@@ -13,27 +13,29 @@ def test_calculate_implied_probabilities():
     with pytest.raises(ValueError):
         shin.calculate_implied_probabilities([0.9, 0.1])
 
-    result = shin.calculate_implied_probabilities([2.6, 2.4, 4.3], full_output=True)
 
-    assert pytest.approx(0.3729941) == result.implied_probabilities[0]
-    assert pytest.approx(0.4047794) == result.implied_probabilities[1]
-    assert pytest.approx(0.2222265) == result.implied_probabilities[2]
-    assert pytest.approx(0.01694251) == result.z
-
-    result = shin.calculate_implied_probabilities(
-        [2.6, 2.4, 4.3], full_output=True, force_python_optimiser=True
+@pytest.mark.parametrize("force_python_optimiser", [True, False])
+def test_calculate_implied_probabilities_full_output(
+    force_python_optimiser: bool,
+) -> None:
+    full_output = shin.calculate_implied_probabilities(
+        [2.6, 2.4, 4.3], full_output=True, force_python_optimiser=force_python_optimiser
     )
 
-    assert pytest.approx(0.3729941) == result.implied_probabilities[0]
-    assert pytest.approx(0.4047794) == result.implied_probabilities[1]
-    assert pytest.approx(0.2222265) == result.implied_probabilities[2]
-    assert pytest.approx(0.01694251) == result.z
+    assert pytest.approx(0.3729941) == full_output.implied_probabilities[0]
+    assert pytest.approx(0.4047794) == full_output.implied_probabilities[1]
+    assert pytest.approx(0.2222265) == full_output.implied_probabilities[2]
+    assert pytest.approx(0.01694251) == full_output.z
 
+
+def test_calculate_implied_probabilities_sequence_input() -> None:
     result = shin.calculate_implied_probabilities([2.6, 2.4, 4.3])
     assert pytest.approx(0.3729941) == result[0]
     assert pytest.approx(0.4047794) == result[1]
     assert pytest.approx(0.2222265) == result[2]
 
+
+def test_calculate_implied_probabilties_mapping_input() -> None:
     result = shin.calculate_implied_probabilities(
         {"HOME": 2.6, "AWAY": 2.4, "DRAW": 4.3}
     )
@@ -43,6 +45,8 @@ def test_calculate_implied_probabilities():
         "DRAW": pytest.approx(0.2222265),
     } == result
 
+
+def test_calculate_implied_probabilities_full_output_mapping_input() -> None:
     result = shin.calculate_implied_probabilities(
         {"HOME": 2.6, "AWAY": 2.4, "DRAW": 4.3}, full_output=True
     )
@@ -53,6 +57,8 @@ def test_calculate_implied_probabilities():
     } == result.implied_probabilities
     assert pytest.approx(0.01694251) == result.z
 
+
+def test_calculate_implied_probabilities_two_outcomes() -> None:
     odds = [1.5, 2.74]
     inverse_odds = [1 / o for o in odds]
     sum_inverse_odds = sum(inverse_odds)

--- a/tests/test_shin.py
+++ b/tests/test_shin.py
@@ -87,4 +87,4 @@ def test_full_output_get_item_interface() -> None:
     assert full_output["delta"] == 0.1
     assert full_output["z"] == 0.5
     with pytest.raises(KeyError):
-        full_output["foo"]
+        full_output["foo"]  # type: ignore[call-overload]

--- a/tests/test_shin.py
+++ b/tests/test_shin.py
@@ -76,3 +76,15 @@ def test_calculate_implied_probabilities_two_outcomes() -> None:
         pytest.approx(inverse_odds[1] - (sum_inverse_odds - 1) / 2)
         == result.implied_probabilities[1]
     )
+
+
+def test_full_output_get_item_interface() -> None:
+    full_output = shin.FullOutput(
+        implied_probabilities=[0.3, 0.4, 0.3], iterations=10, delta=0.1, z=0.5
+    )
+    assert full_output["implied_probabilities"] == [0.3, 0.4, 0.3]
+    assert full_output["iterations"] == 10
+    assert full_output["delta"] == 0.1
+    assert full_output["z"] == 0.5
+    with pytest.raises(KeyError):
+        full_output["foo"]

--- a/tests/test_shin.py
+++ b/tests/test_shin.py
@@ -79,7 +79,7 @@ def test_calculate_implied_probabilities_two_outcomes() -> None:
 
 
 def test_full_output_get_item_interface() -> None:
-    full_output = shin.FullOutput(
+    full_output = shin.ShinOptimisationDetails(
         implied_probabilities=[0.3, 0.4, 0.3], iterations=10, delta=0.1, z=0.5
     )
     assert full_output["implied_probabilities"] == [0.3, 0.4, 0.3]

--- a/typesafety/test_shin.yml
+++ b/typesafety/test_shin.yml
@@ -5,3 +5,35 @@
     reveal_type(shin.optimise)
   out: |
     main:3: note: Revealed type is "def (inverse_odds: builtins.list[builtins.float], sum_inverse_odds: builtins.float, n: builtins.int, max_iterations: builtins.int =, convergence_threshold: builtins.float =) -> tuple[builtins.float, builtins.float, builtins.float]"
+
+- case: test_sequence_input_overload
+  main: |
+    import shin
+    
+    reveal_type(shin.calculate_implied_probabilities([3.0, 3.0, 3.0]))
+  out: |
+    main:3: note: Revealed type is "builtins.list[builtins.float]"
+
+- case: test_mapping_input_overload
+  main: |
+    import shin
+      
+    reveal_type(shin.calculate_implied_probabilities({1: 3.0, 2: 3.0, 3: 3.0}))
+  out: |
+      main:3: note: Revealed type is "builtins.dict[Any, builtins.float]"
+
+- case: test_sequence_input_full_output_overload
+  main: |
+      import shin
+      
+      reveal_type(shin.calculate_implied_probabilities([3.0, 3.0, 3.0], full_output=True))
+  out: |
+      main:3: note: Revealed type is "builtins.dict[builtins.str, Any]"
+
+- case: test_mapping_input_full_output_overload
+  main: |
+      import shin
+      
+      reveal_type(shin.calculate_implied_probabilities({1: 3.0, 2: 3.0, 3: 3.0}, full_output=True))
+  out: |
+      main:3: note: Revealed type is "builtins.dict[builtins.str, Any]"

--- a/typesafety/test_shin.yml
+++ b/typesafety/test_shin.yml
@@ -43,3 +43,26 @@
   out: |
       main:4: note: Revealed type is "shin.FullOutput[builtins.dict[builtins.int, builtins.float]]"
       main:5: note: Revealed type is "builtins.dict[builtins.int, builtins.float]"
+
+- case: test_full_output_get_item_overloads
+  main: |
+      import shin
+    
+      out = shin.calculate_implied_probabilities([3.0, 3.0, 3.0], full_output=True)
+      reveal_type(out['implied_probabilities'])
+      reveal_type(out['iterations'])
+      reveal_type(out['delta'])
+      reveal_type(out['z'])
+      reveal_type(out['other'])
+  out: |
+      main:4: note: Revealed type is "builtins.list[builtins.float]"
+      main:5: note: Revealed type is "builtins.float"
+      main:6: note: Revealed type is "builtins.float"
+      main:7: note: Revealed type is "builtins.float"
+      main:8: error: No overload variant of "__getitem__" of "FullOutput" matches argument type "str"  [call-overload]
+      main:8: note: Possible overload variants:
+      main:8: note:     def __getitem__(self, Literal['implied_probabilities'], /) -> list[float]
+      main:8: note:     def __getitem__(self, Literal['iterations'], /) -> float
+      main:8: note:     def __getitem__(self, Literal['delta'], /) -> float
+      main:8: note:     def __getitem__(self, Literal['z'], /) -> float
+      main:8: note: Revealed type is "Any"

--- a/typesafety/test_shin.yml
+++ b/typesafety/test_shin.yml
@@ -26,14 +26,20 @@
   main: |
       import shin
       
-      reveal_type(shin.calculate_implied_probabilities([3.0, 3.0, 3.0], full_output=True))
+      out = shin.calculate_implied_probabilities([3.0, 3.0, 3.0], full_output=True)
+      reveal_type(out)
+      reveal_type(out.implied_probabilities)
   out: |
-      main:3: note: Revealed type is "shin.FullOutput[builtins.list[builtins.float]]"
+      main:4: note: Revealed type is "shin.FullOutput[builtins.list[builtins.float]]"
+      main:5: note: Revealed type is "builtins.list[builtins.float]"
 
 - case: test_mapping_input_full_output_overload
   main: |
       import shin
       
-      reveal_type(shin.calculate_implied_probabilities({1: 3.0, 2: 3.0, 3: 3.0}, full_output=True))
+      out = shin.calculate_implied_probabilities({1: 3.0, 2: 3.0, 3: 3.0}, full_output=True)
+      reveal_type(out)
+      reveal_type(out.implied_probabilities)
   out: |
-      main:3: note: Revealed type is "shin.FullOutput[builtins.dict[builtins.int, builtins.float]]"
+      main:4: note: Revealed type is "shin.FullOutput[builtins.dict[builtins.int, builtins.float]]"
+      main:5: note: Revealed type is "builtins.dict[builtins.int, builtins.float]"

--- a/typesafety/test_shin.yml
+++ b/typesafety/test_shin.yml
@@ -28,7 +28,7 @@
       
       reveal_type(shin.calculate_implied_probabilities([3.0, 3.0, 3.0], full_output=True))
   out: |
-      main:3: note: Revealed type is "builtins.dict[builtins.str, Any]"
+      main:3: note: Revealed type is "shin.FullOutput[builtins.list[builtins.float]]"
 
 - case: test_mapping_input_full_output_overload
   main: |
@@ -36,4 +36,4 @@
       
       reveal_type(shin.calculate_implied_probabilities({1: 3.0, 2: 3.0, 3: 3.0}, full_output=True))
   out: |
-      main:3: note: Revealed type is "builtins.dict[builtins.str, Any]"
+      main:3: note: Revealed type is "shin.FullOutput[builtins.dict[builtins.int, builtins.float]]"

--- a/typesafety/test_shin.yml
+++ b/typesafety/test_shin.yml
@@ -1,0 +1,3 @@
+- case: test_lib_typing
+  main: |
+    import shin

--- a/typesafety/test_shin.yml
+++ b/typesafety/test_shin.yml
@@ -20,7 +20,7 @@
       
     reveal_type(shin.calculate_implied_probabilities({1: 3.0, 2: 3.0, 3: 3.0}))
   out: |
-      main:3: note: Revealed type is "builtins.dict[Any, builtins.float]"
+      main:3: note: Revealed type is "builtins.dict[builtins.int, builtins.float]"
 
 - case: test_sequence_input_full_output_overload
   main: |

--- a/typesafety/test_shin.yml
+++ b/typesafety/test_shin.yml
@@ -30,7 +30,7 @@
       reveal_type(out)
       reveal_type(out.implied_probabilities)
   out: |
-      main:4: note: Revealed type is "shin.FullOutput[builtins.list[builtins.float]]"
+      main:4: note: Revealed type is "shin.ShinOptimisationDetails[builtins.list[builtins.float]]"
       main:5: note: Revealed type is "builtins.list[builtins.float]"
 
 - case: test_mapping_input_full_output_overload
@@ -41,7 +41,7 @@
       reveal_type(out)
       reveal_type(out.implied_probabilities)
   out: |
-      main:4: note: Revealed type is "shin.FullOutput[builtins.dict[builtins.int, builtins.float]]"
+      main:4: note: Revealed type is "shin.ShinOptimisationDetails[builtins.dict[builtins.int, builtins.float]]"
       main:5: note: Revealed type is "builtins.dict[builtins.int, builtins.float]"
 
 - case: test_full_output_get_item_overloads
@@ -59,7 +59,7 @@
       main:5: note: Revealed type is "builtins.float"
       main:6: note: Revealed type is "builtins.float"
       main:7: note: Revealed type is "builtins.float"
-      main:8: error: No overload variant of "__getitem__" of "FullOutput" matches argument type "str"  [call-overload]
+      main:8: error: No overload variant of "__getitem__" of "ShinOptimisationDetails" matches argument type "str"  [call-overload]
       main:8: note: Possible overload variants:
       main:8: note:     def __getitem__(self, Literal['implied_probabilities'], /) -> list[float]
       main:8: note:     def __getitem__(self, Literal['iterations'], /) -> float

--- a/typesafety/test_shin.yml
+++ b/typesafety/test_shin.yml
@@ -1,3 +1,7 @@
-- case: test_lib_typing
+- case: test_shin_stub
   main: |
-    import shin
+    from shin import shin
+    
+    reveal_type(shin.optimise)
+  out: |
+    main:3: note: Revealed type is "def (inverse_odds: builtins.list[builtins.float], sum_inverse_odds: builtins.float, n: builtins.int, max_iterations: builtins.int =, convergence_threshold: builtins.float =) -> tuple[builtins.float, builtins.float, builtins.float]"


### PR DESCRIPTION
This PR makes a range of changes to support static typing inference of the return types from `calculate_implied_probabilities()`. It:

- adds a framework for testing typesafety
- adds a stub file for the compiled dependency
- uses `__future__.annotations` so we can use the nicer modern typing syntax
- opts to use `Sequence` instead of `Collection` for the non-mapping input type, this implies that order is important as the output list order matches the input odds order.
- BREAKING: makes all other args other than `odds` kw only
- ~BREAKING~: makes output when `full_output=True` a generic dataclass instead of a `dict` - this allows us to preserve the type of the implied odds on the object. (now non-breaking for reads as we implemented `__getitem__` on the dataclass).

All of the changes have been added in individual commits and I've put notes in the commit messages for each.

I understand that the breaking changes might be a bit aggressive, however given that you are still 0-ver - I figured I may as well throw them out there and see what you think. Happy to discuss and make any changes.

Marking the PR as draft as I've not done the CI updates, however code changes are ready for review.

Thanks!